### PR TITLE
Makefile: fix $(LIBS) and $(LDFLAGS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ $(OBJDIR):
 	mkdir -p $(OBJDIR)
 
 $(OBJDIR)/%.o: %.c $(INCLUDES)
-	$(CC) $(CFLAGS) $(LIBS) -c $< -I$(INCDIR) -o $@
+	$(CC) $(CFLAGS) -c $< -I$(INCDIR) -o $@
 
 $(BINDIR)/$(TARGET): $(OBJECTS)
 	mkdir -p $(BINDIR)
-	$(CC) $(CFLAGS) $(LIBS) $^ $(LDFLAGS) $(LIBS) -o $@
+	$(CC) $(LDFLAGS) $^ $(LIBS) -o $@
 
 install: all
 	install -D $(BINDIR)/$(TARGET) -t $(DESTDIR)$(PREFIX)/bin/


### PR DESCRIPTION
This is how I believe it should be.
+ The $(LIBS) are useless when compiling *.c to *.o files
+ The $(LDFLAGS) should be used when linking, $(CFLAGS) redundant there
+ The $^ (object files) should be before the $(LIBS)